### PR TITLE
Adding EVM confirmations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
+name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
@@ -114,12 +120,35 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
+dependencies = [
+ "borsh-derive 0.8.2",
+ "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "borsh"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive",
- "hashbrown",
+ "borsh-derive 0.9.3",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
+dependencies = [
+ "borsh-derive-internal 0.8.2",
+ "borsh-schema-derive-internal 0.8.2",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -128,10 +157,21 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -140,6 +180,17 @@ name = "borsh-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,11 +524,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -605,7 +665,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885db39b08518fa700b73fa2214e8adbbfba316ba82dd510f50519173eadaf73"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "schemars",
  "semver",
  "serde",
@@ -617,8 +677,33 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d258582a1878e6db67400b0504a5099db85718d22c2e07f747fe1706ae7150"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "serde",
+]
+
+[[package]]
+name = "near-crypto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb14bec070cfd808438712cda5d54703001b9cf1196c8afaeadc9514e06d00a3"
+dependencies = [
+ "arrayref",
+ "blake2",
+ "borsh 0.8.2",
+ "bs58",
+ "c2-chacha",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "lazy_static",
+ "libc",
+ "parity-secp256k1",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
 ]
 
 [[package]]
@@ -629,7 +714,7 @@ checksum = "1e75673d69fd7365508f3d32483669fe45b03bfb34e4d9363e90adae9dfb416c"
 dependencies = [
  "arrayref",
  "blake2",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -651,7 +736,10 @@ dependencies = [
 name = "near-mappings"
 version = "0.1.0"
 dependencies = [
+ "hex",
+ "near-crypto 0.1.0",
  "near-sdk",
+ "near-sys",
 ]
 
 [[package]]
@@ -660,14 +748,14 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ad1a9a1640539c81f065425c31bffcfbf6b31ef1aeaade59ce905f5df6ac860"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "bytesize",
  "chrono",
  "derive_more",
  "easy-ext",
  "hex",
- "near-crypto",
+ "near-crypto 0.14.0",
  "near-primitives-core",
  "near-rpc-error-macro",
  "near-vm-errors",
@@ -690,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d508f0fc340f6461e4e256417685720d3c4c00bb5a939b105160e49137caba"
 dependencies = [
  "base64 0.11.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "derive_more",
  "near-account-id",
@@ -729,10 +817,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15eb3de2defe3626260cc209a6cdb985c6b27b0bd4619fad97dcfae002c3c5bd"
 dependencies = [
  "base64 0.13.1",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "near-abi",
- "near-crypto",
+ "near-crypto 0.14.0",
  "near-primitives",
  "near-primitives-core",
  "near-sdk-macros",
@@ -769,7 +857,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0da466a30f0446639cbd788c30865086fac3e8dcb07a79e51d2b0775ed4261e"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -782,17 +870,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b534828419bacbf1f7b11ef7b00420f248c548c485d3f0cfda8bb6931152f2"
 dependencies = [
  "base64 0.13.1",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "byteorder",
  "near-account-id",
- "near-crypto",
+ "near-crypto 0.14.0",
  "near-primitives",
  "near-primitives-core",
  "near-vm-errors",
  "ripemd",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.6",
  "sha3",
  "zeropool-bn",
 ]
@@ -1512,7 +1600,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.1.1"
+near-sys = "0.2"
+near-sdk = { version = "4.1.1", features = ["unstable"] }
+hex = { version = "0.4.3", default-features = false }
+
+[dev-dependencies]
+near-crypto = "0.1.0"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Protocol to maintain mappings between NEAR account and various other blockchain accounts, ip addresses and an
+Protocol to maintain mappings between NEAR account and various other blockchain accounts, ip addresses and other future use cases.
 
 ## Protocol
 
@@ -10,15 +10,25 @@ Maintains map of `<account_id, label> -> <content>`
 
 Contract supports delegating updates to another account via `<account_id> -> <account_id>`
 
+Contract supports validation of values for some specific values. See section below for detailed description.
+
 Protocol has next methods:
-- `set(account_id: Option<AccountId>, label: String, content: Option<String>)` - for given account sets content for label. Account id is either empty or must have delegate to the caller.
-- `get(account_id: AccountId, label: String) -> String` - returns stored content for given account and label.
-- `delegate(account_id: Option<AccountId>)` - allows to delegate control of the caller to given account.
+
+| Function | Description |
+| - | - |
+| `set(id: Option<Id>, label: String, content: Option<String>, proof: Option<String>)` | For given account sets content for this label. Account id is either empty or must have delegate to the caller. `proof` is provided when a |
+| `get(id: Id, label: String, validated: Option<bool>) -> Option<String>` | Returns stored content for given account and label. If `validated` is true and value was not validated, will return `ERR_NOT_VALIDATED` |
+| `delegate(account_id: Option<AccountId>)` | Allows to delegate control of the caller to given account. | 
 
 ## Standards
 
+`Id` can take next options:
+- `{AccountId: account_id}`
+- `{EvmAddress: address}`, where `address` is hex encoded string in the format of `0x...`
+
 | Label | Description | Format |
 | - | - | - |
+| near | List of NEAR account ids | string[] |
 | evm | List of EVM addresses | string[] |
 | ens | List of ENS addresses | string[] |
 | aaaa | AAAA DNS record | string |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
+use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{env, near_bindgen, AccountId, BorshStorageKey, PanicOnDefault};
+
+use crate::validation::validate_evm_address;
+
+mod validation;
 
 #[derive(BorshSerialize, BorshStorageKey)]
 enum StorageKeys {
@@ -8,10 +13,26 @@ enum StorageKeys {
     Delegates,
 }
 
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Id {
+    AccountId(AccountId),
+    EvmAddress(String),
+}
+
+impl ToString for Id {
+    fn to_string(&self) -> String {
+        match self {
+            Id::AccountId(account_id) => format!("near|{}", account_id),
+            Id::EvmAddress(address) => format!("evm|{}", address),
+        }
+    }
+}
+
 #[near_bindgen]
 #[derive(BorshSerialize, BorshDeserialize, PanicOnDefault)]
 struct Contract {
-    mappings: LookupMap<(AccountId, String), String>,
+    mappings: LookupMap<(String, String), String>,
     delegates: LookupMap<AccountId, AccountId>,
 }
 
@@ -25,19 +46,46 @@ impl Contract {
         }
     }
 
-    pub fn set(&mut self, account_id: Option<AccountId>, label: String, content: Option<String>) {
-        let id = if let Some(account_id) = account_id {
-            if env::predecessor_account_id() != account_id {
-                assert_eq!(
-                    self.delegates.get(&account_id).expect("ERR_NOT_DELEGATE"),
-                    env::predecessor_account_id(),
-                    "ERR_NOT_DELEGATE"
-                );
+    /// Returns account id that must be modified or crashes if there is no permissions to write to given account.
+    fn resolve_id(
+        &self,
+        id: Option<Id>,
+        content: &Option<String>,
+        proof: Option<String>,
+    ) -> String {
+        match id {
+            Some(id) => {
+                // Validate ids.
+                match &id {
+                    Id::AccountId(account_id) => {
+                        if &env::predecessor_account_id() != account_id {
+                            assert_eq!(
+                                self.delegates.get(&account_id).expect("ERR_NOT_DELEGATE"),
+                                env::predecessor_account_id(),
+                                "ERR_NOT_DELEGATE"
+                            );
+                        }
+                    }
+                    Id::EvmAddress(address) => {
+                        let signature = proof.expect("ERR_MISSING_SIGNATURE");
+                        validate_evm_address(&address, content, &signature)
+                            .expect("ERR_EVM_INVALID_SIGNATURE");
+                    }
+                }
+                id.to_string()
             }
-            account_id
-        } else {
-            env::predecessor_account_id()
-        };
+            None => env::predecessor_account_id().to_string(),
+        }
+    }
+
+    pub fn set(
+        &mut self,
+        id: Option<Id>,
+        label: String,
+        content: Option<String>,
+        proof: Option<String>,
+    ) {
+        let id = self.resolve_id(id, &content, proof);
         if let Some(content) = content {
             self.mappings.insert(&(id, label), &content);
         } else {
@@ -45,10 +93,8 @@ impl Contract {
         }
     }
 
-    pub fn get(&self, account_id: AccountId, label: String) -> String {
-        self.mappings
-            .get(&(account_id, label))
-            .expect("ERR_NO_VALUE")
+    pub fn get(&self, id: Id, label: String) -> Option<String> {
+        self.mappings.get(&(id.to_string(), label))
     }
 
     pub fn delegate(&mut self, account_id: Option<AccountId>) {
@@ -63,9 +109,11 @@ impl Contract {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::{testing_env, VMContext};
+
+    use super::*;
 
     fn get_context(account_id: &AccountId) -> VMContext {
         VMContextBuilder::new()
@@ -79,21 +127,72 @@ mod tests {
         let account2 = AccountId::new_unchecked("acc2".to_string());
         testing_env!(get_context(&account1));
         let mut c = Contract::new();
-        c.set(None, "label".to_string(), Some("test".to_string()));
-        assert_eq!(c.get(account1.clone(), "label".to_string()), "test");
+        c.set(None, "label".to_string(), Some("test".to_string()), None);
+        assert_eq!(
+            c.get(Id::AccountId(account1.clone()), "label".to_string()),
+            Some("test".to_string())
+        );
         c.set(
-            Some(account1.clone()),
+            Some(Id::AccountId(account1.clone())),
             "label".to_string(),
             Some("test2".to_string()),
+            None,
         );
-        assert_eq!(c.get(account1.clone(), "label".to_string()), "test2");
+        assert_eq!(
+            c.get(Id::AccountId(account1.clone()), "label".to_string()),
+            Some("test2".to_string())
+        );
         c.delegate(Some(account2.clone()));
         testing_env!(get_context(&account2));
         c.set(
-            Some(account1.clone()),
+            Some(Id::AccountId(account1.clone())),
             "label".to_string(),
             Some("test3".to_string()),
+            None,
         );
-        assert_eq!(c.get(account1.clone(), "label".to_string()), "test3");
+        assert_eq!(
+            c.get(Id::AccountId(account1.clone()), "label".to_string()),
+            Some("test3".to_string())
+        );
+    }
+
+    fn public_key_to_address(public_key: PublicKey) -> String {
+        match public_key {
+            PublicKey::ED25519(_) => panic!("Wrong PublicKey"),
+            PublicKey::SECP256K1(pubkey) => {
+                let pk: [u8; 64] = pubkey.into();
+                let bytes = env::keccak256(&pk.to_vec());
+                format!("0x{}", hex::encode(&bytes[12..]))
+            }
+        }
+    }
+
+    fn signature_to_hex(signature: Signature) -> String {
+        match signature {
+            Signature::ED25519(_) => unimplemented!(),
+            Signature::SECP256K1(sig) => hex::encode(&Into::<[u8; 65]>::into(sig)),
+        }
+    }
+
+    #[test]
+    fn test_evm_validation() {
+        let signer = InMemorySigner::from_seed("no_account", KeyType::SECP256K1, "not real seed");
+        let address = public_key_to_address(signer.public_key().clone());
+        let account1 = AccountId::new_unchecked("acc1".to_string());
+        testing_env!(get_context(&account1));
+        let mut c = Contract::new();
+        let content = "[\"a.near\"]".to_string();
+        let signature = signature_to_hex(signer.sign(&env::keccak256(content.as_bytes())));
+        println!("{:?}", signature);
+        c.set(
+            Some(Id::EvmAddress(address.clone())),
+            "near".to_string(),
+            Some(content),
+            Some(signature),
+        );
+        assert_eq!(
+            c.get(Id::EvmAddress(address), "near".to_string()),
+            Some("[\"a.near\"]".to_string())
+        );
     }
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,61 @@
+use near_sdk::env;
+use near_sys as sys;
+
+const ECRECOVER_MESSAGE_SIZE: u64 = 32;
+const ECRECOVER_SIGNATURE_LENGTH: u64 = 64;
+const ECRECOVER_MALLEABILITY_FLAG: u64 = 0;
+
+pub fn validate_evm_address(
+    address: &str,
+    content: &Option<String>,
+    signature: &str,
+) -> Result<(), String> {
+    let address = if address.starts_with("0x") {
+        &address[2..]
+    } else {
+        address
+    };
+    let address = hex::decode(address).map_err(|_| "Invalid address")?;
+    let signature = hex::decode(signature).map_err(|_| "Invalid signature")?;
+    let data = match content {
+        Some(c) => c.as_bytes(),
+        None => "".as_bytes(),
+    };
+    let recovered_address = ecrecover(env::keccak256(data), &signature)
+        .map_err(|_| "Failed to recover address from signature")?;
+    if recovered_address != address {
+        return Err("Incorrect signature".to_string());
+    }
+    Ok(())
+}
+
+fn ecrecover(hash: Vec<u8>, signature: &[u8]) -> Result<Vec<u8>, ()> {
+    unsafe {
+        let hash_ptr = hash.as_ptr() as u64;
+        let sig_ptr = signature.as_ptr() as u64;
+        const RECOVER_REGISTER_ID: u64 = 1;
+        const KECCACK_REGISTER_ID: u64 = 2;
+        let result = sys::ecrecover(
+            ECRECOVER_MESSAGE_SIZE,
+            hash_ptr,
+            ECRECOVER_SIGNATURE_LENGTH,
+            sig_ptr,
+            signature[64] as u64,
+            ECRECOVER_MALLEABILITY_FLAG,
+            RECOVER_REGISTER_ID,
+        );
+        if result == (true as u64) {
+            // The result from the ecrecover call is in a register; we can use this
+            // register directly for the input to keccak256. This is why the length is
+            // set to `u64::MAX`.
+            sys::keccak256(u64::MAX, RECOVER_REGISTER_ID, KECCACK_REGISTER_ID);
+            let keccak_hash_bytes = [0u8; 32];
+            sys::read_register(KECCACK_REGISTER_ID, keccak_hash_bytes.as_ptr() as u64);
+            let mut result = Vec::with_capacity(20);
+            result.extend_from_slice(&keccak_hash_bytes[12..]);
+            Ok(result)
+        } else {
+            Err(())
+        }
+    }
+}


### PR DESCRIPTION
Adding option to confirm evm->near mapping and any other evm related mapping via sending signature.

TODO: need to figure out the exact format of the message that Ethereum wallet should sign to prevent replay attacks.

Fixed #1